### PR TITLE
BasicRoutingInterface

### DIFF
--- a/animated-routing-mixin.js
+++ b/animated-routing-mixin.js
@@ -1,7 +1,8 @@
 import RouteTreeNode from './lib/route-tree-node.js';
 import page from 'page';
 const Context = page.Context;
-import {default as basicRoutingMixin, BasicRoutingInterface} from './routing-mixin.js';
+import {default as basicRoutingMixin} from './routing-mixin.js';
+import { BasicRoutingInterface } from './routing-interface.js';
 
 /**
  * @param {function(new:HTMLElement)} Superclass
@@ -21,7 +22,7 @@ function animatedRoutingMixin(Superclass, className) {
    * @mixinClass
    * @polymer
    * @extends {BasicRoutingElement}
-   * @implements {basicRoutingMixin.Type}
+   * @implements {BasicRoutingInterface}
    */
   class AnimatedRouting extends BasicRoutingElement {
     connectedCallback() {

--- a/animated-routing-mixin.js
+++ b/animated-routing-mixin.js
@@ -1,7 +1,7 @@
 import RouteTreeNode from './lib/route-tree-node.js';
 import page from 'page';
 const Context = page.Context;
-import {default as basicRoutingMixin} from './routing-mixin.js';
+import basicRoutingMixin from './routing-mixin.js';
 import BasicRoutingInterface from './routing-interface.js';
 
 /**

--- a/animated-routing-mixin.js
+++ b/animated-routing-mixin.js
@@ -2,7 +2,7 @@ import RouteTreeNode from './lib/route-tree-node.js';
 import page from 'page';
 const Context = page.Context;
 import {default as basicRoutingMixin} from './routing-mixin.js';
-import { BasicRoutingInterface } from './routing-interface.js';
+import BasicRoutingInterface from './routing-interface.js';
 
 /**
  * @param {function(new:HTMLElement)} Superclass

--- a/lib/route-tree-node.js
+++ b/lib/route-tree-node.js
@@ -21,7 +21,7 @@
 import page from 'page';
 const Context = page.Context;
 import RouteData from './route-data.js';
-import routingMixin from '../routing-mixin.js';
+import { BasicRoutingInterface } from '../routing-interface.js';
 
 class RouteTreeNode {
   /** @param {!RouteData} data */
@@ -297,7 +297,7 @@ class RouteTreeNode {
 
         return nextEntry();
       } else if (currentExitNode.getValue().element) {
-        const routingElem = /** @type {!routingMixin.Type} */ (currentExitNode.getValue().element);
+        const routingElem = /** @type {!BasicRoutingInterface} */ (currentExitNode.getValue().element);
         if (!routingElem.routeExit) {
           throw new Error(`Element '${currentExitNode.getValue().tagName}' does not implement routeExit`);
         }
@@ -319,7 +319,7 @@ class RouteTreeNode {
       if (!currentEntryNode) {
         return;
       } else if (currentEntryNode.getValue().element) {
-        const routingElem = /** @type {!routingMixin.Type} */ (currentEntryNode.getValue().element);
+        const routingElem = /** @type {!BasicRoutingInterface} */ (currentEntryNode.getValue().element);
         if (!routingElem.routeEnter) {
           throw new Error(`Element '${currentEntryNode.getValue().tagName}' does not implement routeEnter`);
         }

--- a/lib/route-tree-node.js
+++ b/lib/route-tree-node.js
@@ -21,7 +21,7 @@
 import page from 'page';
 const Context = page.Context;
 import RouteData from './route-data.js';
-import { BasicRoutingInterface } from '../routing-interface.js';
+import BasicRoutingInterface from '../routing-interface.js';
 
 class RouteTreeNode {
   /** @param {!RouteData} data */

--- a/routing-interface.js
+++ b/routing-interface.js
@@ -26,4 +26,4 @@ const BasicRoutingInterface = class {
   async routeExit(currentNode, nextNode, routeId, context) { }
 };
 
-export {BasicRoutingInterface};
+export {BasicRoutingInterface as default};

--- a/routing-interface.js
+++ b/routing-interface.js
@@ -1,0 +1,29 @@
+
+/** @interface */
+const BasicRoutingInterface = class {
+  /**
+   * Default implementation for the callback on entering a route node.
+   * This will only be used if an element does not define it's own routeEnter method.
+   *
+   * @param {!RouteTreeNode} currentNode
+   * @param {!RouteTreeNode|undefined} nextNodeIfExists
+   * @param {string} routeId
+   * @param {!Context} context
+   * @return {!Promise<boolean|undefined>}
+   */
+  async routeEnter(currentNode, nextNodeIfExists, routeId, context) { }
+
+  /**
+   * Default implementation for the callback on exiting a route node.
+   * This will only be used if an element does not define it's own routeExit method.
+   *
+   * @param {!RouteTreeNode} currentNode
+   * @param {!RouteTreeNode|undefined} nextNode
+   * @param {string} routeId
+   * @param {!Context} context
+   * @return {!Promise<undefined>}
+   */
+  async routeExit(currentNode, nextNode, routeId, context) { }
+};
+
+export {BasicRoutingInterface};

--- a/routing-mixin.js
+++ b/routing-mixin.js
@@ -1,7 +1,7 @@
 import RouteTreeNode from './lib/route-tree-node.js';
 import RouteData from './lib/route-data.js';
 import page from 'page';
-import { BasicRoutingInterface } from './routing-interface.js';
+import BasicRoutingInterface from './routing-interface.js';
 const Context = page.Context;
 
 /**
@@ -114,4 +114,5 @@ function routingMixin(Superclass) {
   return BasicRouting;
 }
 
-export { routingMixin as default };
+//exporting BasicRoutingInterface for backward compatibility - don't break consumer imports
+export { routingMixin as default, BasicRoutingInterface };

--- a/routing-mixin.js
+++ b/routing-mixin.js
@@ -1,34 +1,8 @@
 import RouteTreeNode from './lib/route-tree-node.js';
 import RouteData from './lib/route-data.js';
 import page from 'page';
+import { BasicRoutingInterface } from './routing-interface.js';
 const Context = page.Context;
-
-/** @interface */
-const BasicRoutingInterface = class {
-  /**
-   * Default implementation for the callback on entering a route node.
-   * This will only be used if an element does not define it's own routeEnter method.
-   *
-   * @param {!RouteTreeNode} currentNode
-   * @param {!RouteTreeNode|undefined} nextNodeIfExists
-   * @param {string} routeId
-   * @param {!Context} context
-   * @return {!Promise<boolean|undefined>}
-   */
-  async routeEnter(currentNode, nextNodeIfExists, routeId, context) { }
-
-  /**
-   * Default implementation for the callback on exiting a route node.
-   * This will only be used if an element does not define it's own routeExit method.
-   *
-   * @param {!RouteTreeNode} currentNode
-   * @param {!RouteTreeNode|undefined} nextNode
-   * @param {string} routeId
-   * @param {!Context} context
-   * @return {!Promise<undefined>}
-   */
-  async routeExit(currentNode, nextNode, routeId, context) { }
-};
 
 /**
  * @param {function(new:HTMLElement)} Superclass
@@ -140,4 +114,4 @@ function routingMixin(Superclass) {
   return BasicRouting;
 }
 
-export { BasicRoutingInterface, routingMixin as default };
+export { routingMixin as default };

--- a/test/fixtures/custom-fixture.js
+++ b/test/fixtures/custom-fixture.js
@@ -1,6 +1,6 @@
 import {PolymerElement, html} from '@polymer/polymer/polymer-element.js';
 import {default as routingMixin} from '../../routing-mixin.js';
-import { BasicRoutingInterface } from '../../routing-interface.js';
+import BasicRoutingInterface from '../../routing-interface.js';
 /**
  * @constructor
  * @extends {PolymerElement}

--- a/test/fixtures/custom-fixture.js
+++ b/test/fixtures/custom-fixture.js
@@ -1,6 +1,6 @@
 import {PolymerElement, html} from '@polymer/polymer/polymer-element.js';
-import {default as routingMixin, BasicRoutingInterface} from '../../routing-mixin.js';
-
+import {default as routingMixin} from '../../routing-mixin.js';
+import { BasicRoutingInterface } from '../../routing-interface.js';
 /**
  * @constructor
  * @extends {PolymerElement}


### PR DESCRIPTION
moves the BasicRoutingInterface to it's own file, to avoid circular dependency warnings when using tools like rollup