### PR TITLE
Ditch Node 10 workflow and add Node 16

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x, 16.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
## Summary
This removes the Node 10 workflow requirement because `fs-extra@10.0.0` (required by `streamroller` 3.0.2, which is required by `log4js` 6.4.1) requires Node >= 12

This is also included in, and is a prerequisite for, https://github.com/Banno/web-component-router/pull/16 (Bump log4js from 6.3.0 to 6.4.1), but it still wants the 10.x build to be run. I'm not very familiar right now with GitHub Actions, but I'm hoping splitting this out will fix that.