### PR TITLE
Move the querystring parsing into the Context class

### DIFF
--- a/lib/page.js
+++ b/lib/page.js
@@ -680,7 +680,7 @@ export class Context {
     this.pathname = _page._decodeURLEncodedURIComponent(~i ? path.slice(0, i) : path);
     /** @type {!Object<string, string>} */
     this.params = {};
-    this.query = new URLSearchParams();
+    this.query = new URLSearchParams(this.querystring);
 
     // fragment
     this.hash = '';

--- a/router.js
+++ b/router.js
@@ -196,26 +196,12 @@ class Router {
   }
 
   /**
-   * Adds the query parameters to the Page.js context.
-   *
-   * @param {!Context} context
-   * @param {function():?} next
-   * @private
-   */
-  parseQueryString_(context, next) {
-    context.query = new URLSearchParams(context.querystring);
-    next();
-  }
-
-  /**
    * Walk the route tree and register route nodes with
    * the Page.js router.
    *
    * @private
    */
   registerRoutes_() {
-    this.page.register('*', this.parseQueryString_);
-
     this.routeTree_.traverse((node) => {
       if (node === null) {
         return;

--- a/test/router-spec.js
+++ b/test/router-spec.js
@@ -58,7 +58,7 @@ describe('Router', () => {
 
   it('.start should register routes and start routing', () => {
     const initialCallbackLength = router.page.callbacks.length;
-    const builtinCallbackLength = 1;
+    const builtinCallbackLength = 0;
 
     router.start();
     // router.page should be called to register routes ROOT, B, C, D, E.


### PR DESCRIPTION
Rather than using a callback, updates the `Context` class to directly parse the querystring