### PR TITLE
null check the element nodeName

### DIFF
--- a/lib/page.js
+++ b/lib/page.js
@@ -394,13 +394,13 @@ export class Page {
       for (let i = 0; i < composedPath.length; i++) {
         el = /** @type {!HTMLElement} */ (composedPath[i]);
         // el.nodeName for svg links are 'a' instead of 'A'
-        if (el.nodeName.toUpperCase() === 'A') {
+        if ((el.nodeName || '').toUpperCase() === 'A') {
           break;
         }
       }
     }
 
-    if (!el || el.nodeName.toUpperCase() !== 'A') {
+    if (!el || (el.nodeName || '').toUpperCase() !== 'A') {
       return;
     }
     let anchor = /** @type {!HTMLAnchorElement} */ (el);

--- a/lib/page.js
+++ b/lib/page.js
@@ -389,7 +389,7 @@ export class Page {
     // ensure link
     // use shadow dom when available
     let el = /** @type {!HTMLElement} */ (e.target);
-    if (el.nodeName !== 'A') {
+    if ((el.nodeName || '').toUpperCase() !== 'A') {
       const composedPath = e.composedPath();
       for (let i = 0; i < composedPath.length; i++) {
         el = /** @type {!HTMLElement} */ (composedPath[i]);


### PR DESCRIPTION
The window element in the composed path does not have a nodeName, and applying toUpperCase throws an error in Banno Online.
<img width="789" alt="Screen Shot 2022-08-12 at 11 00 36 AM" src="https://user-images.githubusercontent.com/30597313/184408107-1fbb1abc-f33a-40c5-b662-ba0184e16a6e.png">
