### PR TITLE
Prevent automatically allowing cross-domain route changes

### DIFF
--- a/lib/page.js
+++ b/lib/page.js
@@ -630,7 +630,14 @@ function unhandled(ctx) {
   }
   page.stop();
   ctx.handled = false;
-  isLocation && (window.location.href = ctx.canonicalPath);
+  const url = new URL(ctx.canonicalPath, window.location.origin);
+  if (isLocation) {
+    if (url.origin === window.location.origin) {
+      window.location.href = url.toString();
+    } else {
+      console.error('Cross domain route change prevented');
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
Prevents user input from being used to redirect a user to a malicious site.