### PR TITLE
Reduce recursion

### DIFF
--- a/lib/page.js
+++ b/lib/page.js
@@ -48,7 +48,7 @@ const isLocation = hasWindow && !!(/** @type {?} */ (window.history).location ||
  */
 let PageOptions;
 
-/** @typedef {function(!Context, function():?):?} */
+/** @typedef {function(!Context, function(...?):?):?} */
 let PageCallback;
 
 /** The page instance */
@@ -219,15 +219,15 @@ export class Page {
    * @param {Object=} state
    * @param {boolean=} dispatch
    * @param {boolean=} push
-   * @return {!Context}
+   * @return {!Promise<!Context>}
    */
-  show(path, state, dispatch, push) {
+  async show(path, state, dispatch, push) {
     const ctx = new Context(path, state, this);
     const prev = this.prevContext;
     this.prevContext = ctx;
     this.current = ctx.path;
     if (false !== dispatch) {
-      this.dispatch(ctx, prev);
+      await this.dispatch(ctx, prev);
     }
     if (false !== ctx.handled && false !== push) {
       ctx.pushState();
@@ -314,37 +314,21 @@ export class Page {
    * @param {!Context} ctx
    * @param {!Context} prev
    */
-  dispatch(ctx, prev) {
-    let i = 0;
-    let j = 0;
-    const page = this;
-
-    function nextExit() {
-      let fn = page.exits[j++];
-      if (!fn) {
-        return nextEnter();
-      }
-      fn(prev, nextExit);
-    }
-
-    function nextEnter() {
-      let fn = page.callbacks[i++];
-
-      if (ctx.path !== page.current) {
-        ctx.handled = false;
-        return;
-      }
-      if (!fn) {
-        return unhandled.call(page, ctx);
-      }
-      fn(ctx, nextEnter);
-    }
-
+  async dispatch(ctx, prev) {
     if (prev) {
-      nextExit();
-    } else {
-      nextEnter();
+      // Exit callbacks
+      for (const fn of this.exits) {
+        await new Promise((resolve) => fn(prev, resolve));
+      }
     }
+    // Entry callbacks
+    for (const fn of this.callbacks) {
+      if (ctx.path !== this.current) {
+        ctx.handled = false;
+      }
+      await new Promise((resolve) => fn(ctx, resolve));
+    }
+    unhandled.call(this, ctx);
   }
 
   /**

--- a/router.js
+++ b/router.js
@@ -226,7 +226,9 @@ class Router {
    * @private
    */
   async routeChangeCallback_(routeTreeNode, context, next) {
-    this.routeChangeStartCallbacks_.forEach((cb) => cb());
+    for (const cb of this.routeChangeStartCallbacks_) {
+      cb();
+    }
     this.prevNodeId_ = this.currentNodeId_;
     this.currentNodeId_ = routeTreeNode.getKey();
     /** @type {!Error|undefined} */
@@ -238,7 +240,9 @@ class Router {
     }
     next();
     this.nextStateWasPopped = false;
-    this.routeChangeCompleteCallbacks_.forEach((cb) => cb(routeError));
+    for (const cb of this.routeChangeCompleteCallbacks_) {
+      cb(routeError);
+    }
   }
 
   /**


### PR DESCRIPTION
The callback style used by page.js for middleware produced very deep recursion and caused a minor performance issue. Refactor the code to utilize promises instead.

This is technically a breaking change and will require a major version release. However, no changes were needed in Banno Online to utilize this refactor.