### PR TITLE
fix(syntax): RouteConfig typedef

### DIFF
--- a/router.js
+++ b/router.js
@@ -16,14 +16,16 @@
  */
 
 /**
- * @typedef {Object} RouteConfig
- * @property {string} id
- * @property {string} tagName
- * @property {string} path
- * @property {Array<string>=} params
- * @property {boolean=} authenticated
- * @property {Array<RouteConfig>=} subRoutes
+ * @typedef {{
+ *  id: string,
+ *  tagName: string,
+ *  path: string,
+ *  params: (Array<string>|undefined),
+ *  authenticated: (boolean|undefined),
+ *  subRoutes: (Array<RouteConfig>|undefined),
+ * }}
  */
+let RouteConfig;
 
 import {Context, Page} from './lib/page.js';
 import RouteTreeNode from './lib/route-tree-node.js';


### PR DESCRIPTION
## Summary
This fixes the `RouteConfig` `typedef` annotation that was added in #67 because it currently does not follow the correct syntax (see https://github.com/google/closure-compiler/wiki/Annotating-JavaScript-for-the-Closure-Compiler#typedef-type).


## How to test
1. `yarn link` this repository into a project that uses the router and is compiled with Closure Compiler
2. Run the build
   - There should be no warnings related to the `RouteConfig` type definition