### PR TITLE
Tsc compatibility fixes

### DIFF
--- a/lib/page.js
+++ b/lib/page.js
@@ -15,7 +15,7 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import {pathToRegexp} from 'path-to-regexp/dist.es2015/index.js';
+import {pathToRegexp} from 'path-to-regexp';
 
 /**
  * Short-cuts for global-object checks

--- a/router.js
+++ b/router.js
@@ -23,7 +23,7 @@
  *  params: (Array<string>|undefined),
  *  authenticated: (boolean|undefined),
  *  subRoutes: (Array<RouteConfig>|undefined),
- * }}
+ * }} RouteConfig
  */
 let RouteConfig;
 

--- a/test/karma-init-pre.js
+++ b/test/karma-init-pre.js
@@ -2,6 +2,6 @@ document.write(`<script type="importmap">{
   "imports": {
     "@webcomponents/": "/base/node_modules/@webcomponents/",
     "@polymer/": "/base/node_modules/@polymer/",
-    "path-to-regexp/dist.es2015/index.js": "/base/node_modules/path-to-regexp/dist.es2015/index.js"
+    "path-to-regexp": "/base/node_modules/path-to-regexp/dist.es2015/index.js"
   }
 }\x3c/script>`);


### PR DESCRIPTION
Adjusts the import for `path-to-regexp` in page.js so that it doesn't confuse vite(test) into thinking it's a commonJS module.
Ensures that the RouteConfig type is exported in the router.d.ts file so that it can be imported by typescript.