### PR TITLE
fix:push state when settings context.handled = true

### DIFF
--- a/lib/page.js
+++ b/lib/page.js
@@ -222,12 +222,12 @@ export class Page {
    * @return {!Promise<!Context>}
    */
   async show(path, state, dispatch = true, push = true) {
-    const ctx = new Context(path, state, this);
+    const ctx = new Context(path, state, this, push);
     const prev = this.prevContext;
     this.prevContext = ctx;
     this.current = ctx.path;
     if (false !== dispatch) {
-      await this.dispatch(ctx, prev, push);
+      await this.dispatch(ctx, prev);
     } else if (false !== ctx.handled && false !== push) {
       ctx.pushState();
     }
@@ -312,19 +312,13 @@ export class Page {
    *
    * @param {!Context} ctx
    * @param {!Context} prev
-   * @param {boolean=} push
    */
-  async dispatch(ctx, prev, push = false) {
+  async dispatch(ctx, prev) {
     if (prev) {
       // Exit callbacks
       for (const fn of this.exits) {
         await new Promise((resolve) => fn(prev, resolve));
       }
-    }
-    // Push state before entry callbacks
-    if (false !== push && ctx.path === this.current) {
-      // ignore for now `handled` and always push state
-      ctx.pushState();
     }
     // Entry callbacks
     for (const fn of this.callbacks) {
@@ -646,8 +640,9 @@ export class Context {
    * @param {string|undefined} path
    * @param {*=} state
    * @param {!Page=} pageInstance
+   * @param {boolean=} push Should state be pushed when handled?
    */
-  constructor(path, state, pageInstance) {
+  constructor(path, state, pageInstance, push = false) {
     if (!pageInstance) {
       pageInstance = new Page();
       pageInstance.configure();
@@ -678,6 +673,12 @@ export class Context {
     this.params = {};
     this.query = new URLSearchParams(this.querystring);
 
+    /**
+     * @private
+     * @type {boolean}
+     */
+    this.pushState_ = push;
+
     // fragment
     this.hash = '';
     if (!hashbang) {
@@ -689,11 +690,28 @@ export class Context {
       this.hash = _page._decodeURLEncodedURIComponent(parts[1]) || '';
       this.querystring = this.querystring.split('#')[0];
     }
-    this.handled = false;
+    /**
+     * @private
+     * @type {boolean}
+     */
+    this.handled_ = false;
     /** @type {boolean|undefined} */
     this.init;
     /** @type {string|undefined} */
     this.routePath;
+  }
+
+  /** @param {boolean} value */
+  set handled(value) {
+    if (this.handled_ !== true && value === true && this.pushState_ !== false) {
+      this.pushState();
+    }
+    this.handled_ = value;
+  }
+
+  /** @return {boolean} */
+  get handled() {
+    return this.handled_;
   }
 
   /** Push state. */

--- a/lib/page.js
+++ b/lib/page.js
@@ -221,15 +221,14 @@ export class Page {
    * @param {boolean=} push
    * @return {!Promise<!Context>}
    */
-  async show(path, state, dispatch, push) {
+  async show(path, state, dispatch = true, push = true) {
     const ctx = new Context(path, state, this);
     const prev = this.prevContext;
     this.prevContext = ctx;
     this.current = ctx.path;
     if (false !== dispatch) {
-      await this.dispatch(ctx, prev);
-    }
-    if (false !== ctx.handled && false !== push) {
+      await this.dispatch(ctx, prev, push);
+    } else if (false !== ctx.handled && false !== push) {
       ctx.pushState();
     }
     return ctx;
@@ -313,13 +312,19 @@ export class Page {
    *
    * @param {!Context} ctx
    * @param {!Context} prev
+   * @param {boolean=} push
    */
-  async dispatch(ctx, prev) {
+  async dispatch(ctx, prev, push = false) {
     if (prev) {
       // Exit callbacks
       for (const fn of this.exits) {
         await new Promise((resolve) => fn(prev, resolve));
       }
+    }
+    // Push state before entry callbacks
+    if (false !== push && ctx.path === this.current) {
+      // ignore for now `handled` and always push state
+      ctx.pushState();
     }
     // Entry callbacks
     for (const fn of this.callbacks) {

--- a/test/page-spec.js
+++ b/test/page-spec.js
@@ -1,0 +1,105 @@
+import { Context, Page } from '../lib/page.js';
+
+function JSCompiler_renameProperty(propName, instance) {
+  return propName;
+}
+
+describe('Page', () => {
+  let page;
+
+  beforeEach(() => {
+    page = new Page();
+    spyOn(History.prototype, 'pushState').and.callFake(() => {});
+    spyOn(Context.prototype, 'pushState').and.callFake(() => {});
+  });
+
+  const dispatchPropertyName = JSCompiler_renameProperty('dispatch', Page.prototype);
+  const unhandledPropertyName = JSCompiler_renameProperty('unhandled', Page.prototype);
+
+  describe('show(path, state, dispatch = true, push = true)', () => {
+    const path = '/';
+    const state = {};
+    const dispatch = true;
+    const push = false;
+    beforeEach(() => {
+      spyOn(page, dispatchPropertyName).and.callFake(async () => {});
+    });
+    describe('when dispatch === false', () => {
+      const dispatch = false;
+      it('does not call dispatch(ctx, prev, push)', async () => {
+        await page.show(path, state, dispatch, push);
+        expect(page.dispatch).not.toHaveBeenCalled();
+      });
+      describe('when push === true', () => {
+        const push = true;
+        it('calls context.pushState() synchronously', () => {
+          page.show(path, state, dispatch, push);
+          expect(Context.prototype.pushState).toHaveBeenCalled();
+        });
+      });
+      describe('when push === false', () => {
+        const push = false;
+        it('does not call context.pushState()', async () => {
+          await page.show(path, state, dispatch, push);
+          expect(Context.prototype.pushState).not.toHaveBeenCalled();
+        });
+      });
+    });
+    describe('when dispatch === true', () => {
+      const dispatch = true;
+      it('calls dispatch(ctx, prev, push)', () => {
+        const prev = page.prevContext;
+        page.show(path, state, dispatch, push);
+        expect(page.dispatch).toHaveBeenCalledWith(jasmine.any(Context), prev, push);
+      });
+      describe('when push === false', () => {
+        const push = false;
+        it('does not call context.pushState()', async () => {
+          await page.show(path, state, dispatch, push);
+          expect(Context.prototype.pushState).not.toHaveBeenCalled();
+        });
+      });
+    });
+  });
+
+  describe('dispatch(ctx, prev, push)', () => {
+    let ctx;
+    let prev;
+    const state = {};
+    const prevState = {};
+    beforeEach(() => {
+      ctx = new Context('/next', state, page);
+      prev = new Context('/prev', prevState, page);
+      // add entry callback to handle context to ensure that the `unhandled` callback doesn't do a full page reload
+      page.callbacks.push((ctx, next) => { ctx.handled = true; next(); });
+    });
+    describe('when push === true and ctx.path === page.current', () => {
+      const push = true;
+      beforeEach(() => {
+        page.current = ctx.path;
+      })
+      it('calls context.pushState() asynchronously between exit and entry callbacks', async () => {
+        const exitCallback = (ctx, next) => {
+          // expect `pushState` to have been called before entry callback
+          expect(Context.prototype.pushState).not.toHaveBeenCalled(); // not yet
+          ctx.state['exitCallbackCalled'] = true;
+          next();
+        }
+        const entryCallback = (ctx, next) => {
+          // expect `pushState` to have been called before entry callback
+          expect(Context.prototype.pushState).toHaveBeenCalled();
+          ctx.handled = true;
+          next();
+        }
+        page.exits.push(exitCallback);
+        page.callbacks.push(entryCallback);
+
+        const dispatchPromise = page.dispatch(ctx, prev, push);
+        expect(ctx.handled).toBe(undefined); // entry callback should not have been called yet
+        await dispatchPromise;
+        expect(prevState['exitCallbackCalled']).toBe(true); // exit handler should have been called
+        expect(ctx.handled).toBe(true); // sanity check to ensure that the entry callback was called
+      });
+    });
+  });
+});


### PR DESCRIPTION
## What it does
Before https://github.com/Banno/web-component-router/pull/65, `history.pushState()` was called on a route change (`page.show()`) between the exit and entry callbacks—if the exit callbacks were not asynchronous. This is the correct place for state to be pushed, but it worked like this somewhat unintentionally because it happened after the `await` in `routeChangeCallback_()`.

However, https://github.com/Banno/web-component-router/pull/65 changed the timing of this call so it is not called until all route exit and entry callbacks are complete (`await page.dispatch()`). This means that the new state is not accessible from the entry callbacks (i.e. `routeEnter()`), and that makes the router much more difficult to use.

This makes some changes to the `page.show()` function and `Context` class so `history.pushState()` is called when the `Context`'s `handled` property is changed to `true`.

* Creates accessors for `Context.prototype.handled` so `Context.prototype.pushState()` is called on the object when the `handled` property is set from non-true to `true`
* Adds optional `push` parameters to `page.show()` (default: `true`) and `Context` constructor (default: `false`) to indicate whether `Context.prototype.pushState()` should be called when the `handled` property is set from non-true to `true`