### PR TITLE
fix(dispatch): reset ctx.handled only before first callback

### DIFF
--- a/lib/page.js
+++ b/lib/page.js
@@ -321,10 +321,10 @@ export class Page {
       }
     }
     // Entry callbacks
+    if (ctx.path !== this.current) {
+      ctx.handled = false;
+    }
     for (const fn of this.callbacks) {
-      if (ctx.path !== this.current) {
-        ctx.handled = false;
-      }
       await new Promise((resolve) => fn(ctx, resolve));
     }
     unhandled.call(this, ctx);


### PR DESCRIPTION
## Summary

Fixes a bug where `ctx.handled` is incorrectly reset to `false` before each callback, causing the _unhandled_ handler to be called unless the last entry handler sets `context.handled = true`. Instead, this changes it so `handled` is set to `false` immediately before the first entry callback.