### PR TITLE
Adding ability to use a 404 route

### DIFF
--- a/router.js
+++ b/router.js
@@ -253,6 +253,12 @@ class Router {
    * @private
    */
   async routeChangeCallback_(routeTreeNode, context, next) {
+    const { routePath, handled } = context;
+
+    if (routePath === '(.*)' && handled) {
+      return;
+    }
+
     for (const cb of this.routeChangeStartCallbacks_) {
       cb();
     }

--- a/test/router-spec.js
+++ b/test/router-spec.js
@@ -328,4 +328,35 @@ describe('Router', () => {
       expect(A.getValue().element.getElementsByTagName(testRouteTree.Id.B).length).toBe(0);
     });
   });
+
+  describe('404 route', () => {
+    beforeAll(() => {
+      spyOn(testRouteTree, 'activate').and.callThrough();
+      router.routeChangeCompleteCallbacks_.add(() => {});
+    });
+
+    it('should not call route activate if the context has been handled and the route is (.*)', async () => {
+      const context = { handled: true, routePath: '(.*)'}
+      router.routeChangeCallback_(testRouteTree, context, () => null);
+      expect(testRouteTree.activate).not.toHaveBeenCalled();
+    });
+
+    it('should call route activate if the context has NOT been handled and the route is (.*)', async () => {
+      const context = { handled: false, routePath: '(.*)'}
+      router.routeChangeCallback_(testRouteTree, context, () => null);
+      expect(testRouteTree.activate).toHaveBeenCalled();
+    });
+
+    it('should call route activate if the context has been handled BUT the route is NOT (.*)', async () => {
+      const context = { handled: true, routePath: '/'}
+      router.routeChangeCallback_(testRouteTree, context, () => null);
+      expect(testRouteTree.activate).toHaveBeenCalled();
+    });
+
+    it('should call route activate if the context has NOT been handled AND the route is NOT (.*)', async () => {
+      const context = { handled: false, routePath: '/'}
+      router.routeChangeCallback_(testRouteTree, context, () => null);
+      expect(testRouteTree.activate).toHaveBeenCalled();
+    });
+  })
 });

--- a/test/utils/testing-route-setup.js
+++ b/test/utils/testing-route-setup.js
@@ -57,5 +57,7 @@ ROOT.addChild(D);
 
 export default {
   tree: ROOT,
-  Id: RouteId
+  Id: RouteId,
+  activate: async () => null,
+  getKey: () => 'test',
 };


### PR DESCRIPTION
In page.js you can define a 404 route, using '*' as your path.

In the router, this route's callback is still called after the callback of any route that might also have a triggered routePath.

What we want is for the * path to only be activated if the context has not been handled.


To test:  
1. Tests should pass.
2. Checkout this branch in digital-tools, yarn link web-component-router and run yarn serve in the example-dashboard-app
2a. Go to the dashboard page, the 404 should not show.  Add /sdfahsdkjfh or something to the url, the 404 page should show.