### PR TITLE
chore(deps-dev): remove Lit dependency

### DIFF
--- a/lib/animated-routing.mixin.ts
+++ b/lib/animated-routing.mixin.ts
@@ -1,8 +1,7 @@
-import {type LitElement} from 'lit';
 import {type Constructor, type RoutingMixinInterface} from './routing.mixin.js';
 import animatedRouteMixin from './animated-routing-mixin.js';
 
-function animatedRoutingMixin<T extends Constructor<LitElement>>(Superclass:T, className:string) {
+function animatedRoutingMixin<T extends Constructor<HTMLElement>>(Superclass:T, className:string) {
   return animatedRouteMixin(Superclass, className) as unknown as Constructor<RoutingMixinInterface> & T;
 }
 

--- a/lib/routing.mixin.ts
+++ b/lib/routing.mixin.ts
@@ -1,14 +1,13 @@
 import BasicRoutingInterface from './routing-interface.js';
 import type { Context } from './page.js';
 import type RouteTreeNode from './route-tree-node.js';
-import type { LitElement } from 'lit';
 import routingMixin from './routing-mixin.js';
 export type Constructor<T = {}> = new (...args: any[]) => T;
 export declare class RoutingMixinInterface {
   routeEnter(currentNode: RouteTreeNode, nextNodeIfExists: RouteTreeNode | undefined, routeId: string, context: Context): Promise<boolean | void>;
   routeExit(currentNode: RouteTreeNode, nextNode: RouteTreeNode | undefined, routeId: string, context: Context): Promise<boolean | void>;
 }
-const RoutingMixin = <T extends Constructor<LitElement>>(superclass: T) => {
+const RoutingMixin = <T extends Constructor<HTMLElement>>(superclass: T) => {
   return routingMixin(superclass) as unknown as Constructor<RoutingMixinInterface> & T;
 };
 

--- a/package.json
+++ b/package.json
@@ -45,10 +45,6 @@
     "karma-chrome-launcher": "^3.2.0",
     "karma-jasmine": "5.x",
     "karma-spec-reporter": "^0.0.36",
-    "lit": "^3.1.3",
     "typescript": "^5.2.2"
-  },
-  "peerDependencies": {
-    "lit": "^3.1.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,18 +7,6 @@
   resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
   integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
 
-"@lit-labs/ssr-dom-shim@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.2.0.tgz#353ce4a76c83fadec272ea5674ede767650762fd"
-  integrity sha512-yWJKmpGE6lUURKAaIltoPIE/wrbY3TEkqQt+X0m+7fQNnAv0keydnYvbiJFP1PnMhizmIWRWOG5KLhYyc/xl+g==
-
-"@lit/reactive-element@^2.0.4":
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/@lit/reactive-element/-/reactive-element-2.0.4.tgz#8f2ed950a848016383894a26180ff06c56ae001b"
-  integrity sha512-GFn91inaUa2oHLak8awSIigYz0cU0Payr1rcFsrkf5OJ5eSPxElyZfKh0f2p9FsTiZWXQdWGJeXZICEfXXYSXQ==
-  dependencies:
-    "@lit-labs/ssr-dom-shim" "^1.2.0"
-
 "@polymer/polymer@^3.4.1":
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/@polymer/polymer/-/polymer-3.5.1.tgz#4b5234e43b8876441022bcb91313ab3c4a29f0c8"
@@ -52,11 +40,6 @@
   version "18.11.18"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.18.tgz#8dfb97f0da23c2293e554c5a50d61ef134d7697f"
   integrity sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==
-
-"@types/trusted-types@^2.0.2":
-  version "2.0.7"
-  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.7.tgz#baccb07a970b91707df3a3e8ba6896c57ead2d11"
-  integrity sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==
 
 "@webcomponents/shadycss@^1.9.1":
   version "1.10.0"
@@ -593,31 +576,6 @@ karma@^6.x:
     tmp "^0.2.1"
     ua-parser-js "^0.7.30"
     yargs "^16.1.1"
-
-lit-element@^4.0.4:
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/lit-element/-/lit-element-4.0.5.tgz#f20cd8a6231eaf5358f7a6877ca6ea7628fa2015"
-  integrity sha512-iTWskWZEtn9SyEf4aBG6rKT8GABZMrTWop1+jopsEOgEcugcXJGKuX5bEbkq9qfzY+XB4MAgCaSPwnNpdsNQ3Q==
-  dependencies:
-    "@lit-labs/ssr-dom-shim" "^1.2.0"
-    "@lit/reactive-element" "^2.0.4"
-    lit-html "^3.1.2"
-
-lit-html@^3.1.2:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-3.1.3.tgz#ae2e9fee0258d0a1b5d7b86c87da51117e4f911b"
-  integrity sha512-FwIbqDD8O/8lM4vUZ4KvQZjPPNx7V1VhT7vmRB8RBAO0AU6wuTVdoXiu2CivVjEGdugvcbPNBLtPE1y0ifplHA==
-  dependencies:
-    "@types/trusted-types" "^2.0.2"
-
-lit@^3.1.3:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/lit/-/lit-3.1.4.tgz#03a72e9f0b1f5da317bf49b1ab579a7132e73d7a"
-  integrity sha512-q6qKnKXHy2g1kjBaNfcoLlgbI3+aSOZ9Q4tiGa9bGYXq5RBXxkVTqTIVmP2VWMp29L4GyvCFm8ZQ2o56eUAMyA==
-  dependencies:
-    "@lit/reactive-element" "^2.0.4"
-    lit-element "^4.0.4"
-    lit-html "^3.1.2"
 
 lodash@^4.17.21:
   version "4.17.21"


### PR DESCRIPTION
## Summary

The `lit` dependency is only used for the TypeScript mixins. However, the constructor should not be required to be a Lit element, as it should work with any web component. 

* Removes the `lit` dependency
* Replaces the `LitElement` type with `HTMLElement`