### PR TITLE
feat(router): Update beforeEnter typing

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ import RouteData from '@jack-henry/web-component-router/lib/route-data.js';
  *     These should match to named path segments. Each camel case name
  *     is converted to a hyphenated name to be assigned to the element.
  * @param {boolean=} requiresAuthentication (optional - defaults true)
- * @param {function():Promise<undefined>=} beforeEnter Optionally allows you to dynamically import the component for a given route.  The route-mixin.js will call your beforeEnter on routeEnter if the component does not exist in the dom.
+ * @param {function():(Promise<unknown>|undefined)=} beforeEnter Optionally allows you to dynamically import the component for a given route.  The route-mixin.js will call your beforeEnter on routeEnter if the component does not exist in the dom.
  */
 const routeData = new RouteData(
     'Name of this route',

--- a/lib/route-data.js
+++ b/lib/route-data.js
@@ -8,7 +8,7 @@ class RouteData {
    * @param {!Array<string>=} namedParameters list in camelCase. Will be
    *     converted to a map of camelCase and hyphenated.
    * @param {boolean=} requiresAuthentication
-   * @param {function():Promise<undefined>=} beforeEnter
+   * @param {function():(Promise<unknown>|undefined)=} beforeEnter
    */
   constructor(id, tagName, path, namedParameters, requiresAuthentication, beforeEnter) {
     namedParameters = namedParameters || [];

--- a/router.js
+++ b/router.js
@@ -23,7 +23,7 @@
  *  params: (Array<string>|undefined),
  *  authenticated: (boolean|undefined),
  *  subRoutes: (Array<RouteConfig>|undefined),
- *  beforeEnter: (function():Promise<undefined>|undefined)
+ *  beforeEnter?: (function():Promise<unknown>|undefined)
  * }} RouteConfig
  */
 let RouteConfig;


### PR DESCRIPTION
Updates the `beforeEnter` typing so that instead of `Promise<undefined>` we have `Promise<unknown>` because when implementing dynamic imports in the `beforeEnter` function the TS linter gives errors about the type of the dynamic import.