### PR TITLE
fix(router): remove beforeEnter return type

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ import RouteData from '@jack-henry/web-component-router/lib/route-data.js';
  *     These should match to named path segments. Each camel case name
  *     is converted to a hyphenated name to be assigned to the element.
  * @param {boolean=} requiresAuthentication (optional - defaults true)
- * @param {function():(Promise<unknown>|undefined)=} beforeEnter Optionally allows you to dynamically import the component for a given route.  The route-mixin.js will call your beforeEnter on routeEnter if the component does not exist in the dom.
+ * @param {function():Promise=} beforeEnter Optionally allows you to dynamically import the component for a given route.  The route-mixin.js will call your beforeEnter on routeEnter if the component does not exist in the dom.
  */
 const routeData = new RouteData(
     'Name of this route',

--- a/lib/route-data.js
+++ b/lib/route-data.js
@@ -8,7 +8,7 @@ class RouteData {
    * @param {!Array<string>=} namedParameters list in camelCase. Will be
    *     converted to a map of camelCase and hyphenated.
    * @param {boolean=} requiresAuthentication
-   * @param {function():(Promise<unknown>|undefined)=} beforeEnter
+   * @param {function():Promise=} beforeEnter
    */
   constructor(id, tagName, path, namedParameters, requiresAuthentication, beforeEnter) {
     namedParameters = namedParameters || [];

--- a/router.js
+++ b/router.js
@@ -23,7 +23,7 @@
  *  params: (Array<string>|undefined),
  *  authenticated: (boolean|undefined),
  *  subRoutes: (Array<RouteConfig>|undefined),
- *  beforeEnter?: (function():Promise<unknown>|undefined)
+ *  beforeEnter: (function():Promise)
  * }} RouteConfig
  */
 let RouteConfig;


### PR DESCRIPTION
## Summary
The Typescript-specific `unknown` type doesn't play well with Google Closure Compiler. However, it shouldn't matter what the return type of the `beforeEnter` promise is.. it should just return a `Promise`. This is a follow-up to https://github.com/Banno/web-component-router/pull/119 to remove `unknown|undefined` on the `beforeEnter` promise return type so it should play nicely with Typescript and Closure Compiler.

