### PR TITLE
feat: add lifecycle methods to route config

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,35 @@ import animatedRouteMixin from '@jack-henry/web-component-router/animated-routin
 class MyElement extends animatedRouteMixin(HTMLElement, 'className') { }
 ```
 
+## Lifecycle Hook Execution Order
+
+The `@jack-henry/web-component-router` allows you to define lifecycle hooks at two levels:
+
+1. **Route Configuration:** Within the `RouteData` object or the equivalent properties in the route config object (`beforeEnter`, `routeEnter`, `routeExit`).
+2. **Component Methods:** By overriding the corresponding methods (`beforeEnter`, `routeEnter`, `routeExit`) in your web component, especially when using the `routingMixin`.
+
+When navigating between routes, the router executes these hooks in a specific, hierarchical order for each node in the route tree that is part of the transition (either entering or exiting).
+
+**During Route Entry:**
+
+When entering a new route, the following hooks are executed sequentially for each relevant node, starting from the top of the route tree down to the target node:
+
+1. `beforeEnter` function defined in the **Route Configuration** (`RouteData` or config object).
+2. `beforeEnter` method overridden on the **Component Instance**.
+3. `routeEnter` function defined in the **Route Configuration** (`RouteData` or config object).
+4. `routeEnter` method overridden on the **Component Instance**.
+
+**During Route Exit:**
+
+When exiting a route, the following hooks are executed sequentially for each relevant node, starting from the node being exited up towards the common ancestor node:
+
+1. `routeExit` method overridden on the **Component Instance**.
+2. `routeExit` function defined in the **Route Configuration** (`RouteData` or config object).
+
+This hierarchical execution allows you to perform actions specific to the route definition first (e.g., data fetching or component import in `beforeEnter` config), followed by component-specific logic in the overridden methods.
+
+Hooks can be defined in one or both locations. If a hook is defined in both the route configuration and the component, both will be called in the order specified above. If defined in only one location, only that definition will be executed for that specific hook and node.
+
 ## Root App Element
 
 The routing configuration is typically defined inside the main app element
@@ -318,7 +347,7 @@ The root element typically has a slightly different configuration.
 import myAppRouteTree from './route-tree.js';
 import router, {Context, routingMixin} from '@jack-henry/web-component-router';
 
-class AppElement extends routingMixin(Polymer.Element) {
+class AppElement extends routingMixin(LitElement) {
   static get is() { return 'app-element'; }
 	isAuthenticated = false;
   connectedCallback() {
@@ -372,7 +401,7 @@ issue.
 import myAppRouteTree from './route-tree.js';
 import router, {routingMixin} from '@jack-henry/web-component-router';
 
-class AppElement extends routingMixin(Polymer.Element) {
+class AppElement extends routingMixin(LitElement) {
   static get is() { return 'app-element'; }
 
   connectedCallback() {

--- a/README.md
+++ b/README.md
@@ -146,19 +146,28 @@ const routeConfig = {
     id: 'app',
     tagName: 'APP-MAIN',
     path: '',
+    beforeEnter: (currentNode, nextNodeIfExists, routeId, context) => {
+			await setupServices();
+    }
+    routeEnter: (currentNode, nextNodeIfExists, routeId, context) => {
+      doSomething();
+    }
+    routeExit: (currentNode, nextNode, routeId, context) => {
+      teardownServices();
+    }
     subRoutes: [{
         id: 'app-user',
         tagName: 'APP-USER-PAGE',
         path: '/users/:userId([0-9]{1,6})',
         params: ['userId'],
-        beforeEnter: () => {
+        beforeEnter: (currentNode, nextNodeIfExists, routeId, context) => {
         	isAuthorized();
         	import('../app-user-page.js')
         }
-        routeEnter: () => {
+        routeEnter: (currentNode, nextNodeIfExists, routeId, context) => {
         	doSomething();
         }
-        routeExit: () => {
+        routeExit: (currentNode, nextNode, routeId, context) => {
         	saveDataToCache();
         }
     }, {
@@ -166,14 +175,14 @@ const routeConfig = {
         tagName: 'APP-ACCOUNT-PAGE',
         path: '/users/:userId([0-9]{1,6})/accounts/:accountId([0-9]{1,6})',
         params: ['userId', 'accountId'],
-        beforeEnter: () => {
+        beforeEnter: (currentNode, nextNodeIfExists, routeId, context) => {
         	isAuthorized();
         	import('../app-account-page.js')
         }
-        routeEnter: () => {
+        routeEnter: (currentNode, nextNodeIfExists, routeId, context) => {
         	doSomething();
         }
-        routeExit: () => {
+        routeExit: (currentNode, nextNode, routeId, context) => {
         	saveDataToCache();
         }
     }, {
@@ -181,14 +190,14 @@ const routeConfig = {
       tagName: 'APP-ABOUT',
       path: '/about',
       authenticated: false,
-      beforeEnter: () => {
+      beforeEnter: (currentNode, nextNodeIfExists, routeId, context) => {
         isAuthorized();
         import('../app-about.js);
       }
-      routeEnter: () => {
+      routeEnter: (currentNode, nextNodeIfExists, routeId, context) => {
         doSomething();
       }
-      routeExit: () => {
+      routeExit: (currentNode, nextNode, routeId, context) => {
         saveDataToCache();
       }
     }]

--- a/lib/route-data.js
+++ b/lib/route-data.js
@@ -1,5 +1,40 @@
 /** @fileoverview Basic data for a route */
-
+/**
+ * @callback BeforeEnterFunction
+ * @param {!Object} currentNode - The current route node.
+ * @param {(Object|undefined)} nextNodeIfExists - The next route node, if one exists.
+ * @param {string} routeId - The ID of the route being entered.
+ * @param {!Object} context - A context object, potentially containing shared state or utilities.
+ * @returns {Promise<boolean|void>} Should return a Promise.
+ * Resolves to `true` or `void` to allow navigation.
+ * Resolves to `false` to prevent navigation.
+ *
+ * Defines the signature for the beforeEnter lifecycle hook.
+ */
+/**
+ * @callback RouteEnterFunction
+ * @param {!Object} currentNode - The current route node.
+ * @param {(Object|undefined)} nextNodeIfExists - The next route node, if one exists.
+ * @param {string} routeId - The ID of the route being entered.
+ * @param {!Object} context - A context object, potentially containing shared state or utilities.
+ * @returns {Promise<boolean|void>} Should return a Promise.
+ * Resolves to `true` or `void` to allow navigation.
+ * Resolves to `false` to prevent navigation.
+ *
+ * Defines the signature for the routeEnter lifecycle hook.
+ */
+/**
+ * @callback RouteExitFunction
+ * @param {!Object} currentNode - The current route node.
+ * @param {(Object|undefined)} nextNode - The next route node, if one exists.
+ * @param {string} routeId - The ID of the route being entered.
+ * @param {!Object} context - A context object, potentially containing shared state or utilities.
+ * @returns {Promise<boolean|void>} Should return a Promise.
+ * Resolves to `true` or `void` to allow navigation.
+ * Resolves to `false` to prevent navigation.
+ *
+ * Defines the signature for the routeEnter lifecycle hook.
+ */
 class RouteData {
   /**
    * @param {string} id of this route
@@ -8,9 +43,12 @@ class RouteData {
    * @param {!Array<string>=} namedParameters list in camelCase. Will be
    *     converted to a map of camelCase and hyphenated.
    * @param {boolean=} requiresAuthentication
-   * @param {function():Promise=} beforeEnter
+   * @param {BeforeEnterFunction=} beforeEnter Function to execute before the route is entered.
+   * @param {RouteEnterFunction=} routeEnter Function to execute when the route is entered.
+   * @param {RouteExitFunction=} routeExit Function to execute when the route is exited.
    */
-  constructor(id, tagName, path, namedParameters, requiresAuthentication, beforeEnter) {
+
+  constructor(id, tagName, path, namedParameters, requiresAuthentication, beforeEnter, routeEnter, routeExit) {
     namedParameters = namedParameters || [];
     /** @type {!Object<string, string>} */
     const params = {};
@@ -30,7 +68,23 @@ class RouteData {
     this.element = undefined;
     this.requiresAuthentication = requiresAuthentication !== false;
 
-    this.beforeEnter = beforeEnter || (() => Promise.resolve());
+    /**
+     * The function to execute before entering the route.
+     * @type {BeforeEnterFunction}
+     */
+    this.beforeEnter = beforeEnter || ((currentNode, nextNodeIfExists, routeId, context) => Promise.resolve());
+
+    /**
+     * The function to execute before entering the route.
+     * @type {RouteExitFunction}
+     */
+    this.routeEnter = routeEnter || ((currentNode, nextNodeIfExists, routeId, context) => Promise.resolve());
+
+    /**
+     * The function to execute before entering the route.
+     * @type {RouteExitFunction}
+     */
+    this.routeExit = routeExit || ((currentNode, nextNode, routeId, context) => Promise.resolve());
   }
 }
 

--- a/lib/route-tree-node.js
+++ b/lib/route-tree-node.js
@@ -307,7 +307,7 @@ class RouteTreeNode {
       const routingElem = /** @type {!BasicRoutingInterface} */ (/** @type {?} */ (currentEntryNode.getValue().element));
       if (routingElem) {
         if (routeData?.beforeEnter) {
-          const shouldContinue = await routingElem.beforeEnter(currentEntryNode, nextEntryNode, routeId, context);
+          const shouldContinue = await routeData.beforeEnter(currentEntryNode, nextEntryNode, routeId, context);
           if (shouldContinue === false) {
             break;
           }

--- a/lib/route-tree-node.js
+++ b/lib/route-tree-node.js
@@ -18,7 +18,7 @@
  * @see https://google.github.io/closure-library/api/goog.structs.TreeNode.html
  */
 
-import {Context} from './page.js';
+import { Context } from './page.js';
 import RouteData from './route-data.js';
 import BasicRoutingInterface from './routing-interface.js';
 
@@ -202,8 +202,7 @@ class RouteTreeNode {
    * @return {RouteTreeNode} The removed node if any.
    */
   removeChild(child) {
-    return child &&
-      this.removeChildAt(this.getChildren().indexOf(child));
+    return child && this.removeChildAt(this.getChildren().indexOf(child));
   }
 
   /** @return {boolean} */
@@ -286,28 +285,45 @@ class RouteTreeNode {
     for (let exitIndex = 0; exitIndex < exitNodes.length; exitIndex++) {
       const currentExitNode = exitNodes[exitIndex];
       const nextExitNode = exitNodes[exitIndex + 1];
-      const value = currentExitNode.getValue();
-      if (value) {
-        const routingElem = /** @type {!BasicRoutingInterface} */ (
-            /** @type {?} */ (currentExitNode.getValue().element)
-        );
+      const routeData /** @type {!RouteData} */ = currentExitNode.getValue();
+
+      const routingElem = /** @type {!BasicRoutingInterface} */ (/** @type {?} */ (currentExitNode.getValue().element));
+      if (routingElem) {
         if (!routingElem.routeExit) {
           throw new Error(`Element '${currentExitNode.getValue().tagName}' does not implement routeExit`);
         }
+        if (routeData.routeExit) {
+          await routeData.routeExit(currentExitNode, nextExitNode, routeId, context);
+        }
         await routingElem.routeExit(currentExitNode, nextExitNode, routeId, context);
-        value.element = undefined;
       }
+      routeData.element = undefined;
     }
-
     // entry nodes
     for (let entryIndex = 0; entryIndex < entryNodes.length; entryIndex++) {
       const currentEntryNode = entryNodes[entryIndex];
       const nextEntryNode = entryNodes[entryIndex + 1];
-
-      if (currentEntryNode.getValue().element) {
-        const routingElem = /** @type {!BasicRoutingInterface} */ (
-            /** @type {?} */ (currentEntryNode.getValue().element)
-        );
+      const routeData /** @type {!RouteData} */ = currentEntryNode.getValue();
+      const routingElem = /** @type {!BasicRoutingInterface} */ (/** @type {?} */ (currentEntryNode.getValue().element));
+      if (routingElem) {
+        if (routeData?.beforeEnter) {
+          const shouldContinue = await routingElem.beforeEnter(currentEntryNode, nextEntryNode, routeId, context);
+          if (shouldContinue === false) {
+            break;
+          }
+        }
+        if (routingElem.beforeEnter) {
+          const shouldContinue = await routingElem.beforeEnter(currentEntryNode, nextEntryNode, routeId, context);
+          if (shouldContinue === false) {
+            break;
+          }
+        }
+        if (routeData?.routeEnter) {
+          const shouldContinue = await routeData.routeEnter(currentEntryNode, nextEntryNode, routeId, context);
+          if (shouldContinue === false) {
+            break;
+          }
+        }
         if (!routingElem.routeEnter) {
           throw new Error(`Element '${currentEntryNode.getValue().tagName}' does not implement routeEnter`);
         }

--- a/lib/route-tree-node.js
+++ b/lib/route-tree-node.js
@@ -220,13 +220,22 @@ class RouteTreeNode {
 
   /**
    * Cause this route to become the active route. When a route is activated,
-   * exitCallback functions from the routeData should be called up the tree in order
+   * routeExit functions from the routeData should be called up the tree in order
    * beginning with the previousNodeId until a common node is found with the
    * path from the root to this node.
    *
-   * After exitCallback methods have all completed, entryCallbacks should
+   * After routeExit methods have all completed, beforeEntry and routeEnter callbacks should
    * be called in order beginning with the root node down the tree through
    * this node.
+   *
+   * Route lifecycle methods (`routeExit`, `beforeEnter`, `routeEnter`) can be defined
+   * in the `routeData` object and/or on the associated `routingElement` (if it
+   * implements `BasicRoutingInterface`). Both implementations, if they exist,
+   * will be called for the respective phase. For entry hooks, `beforeEnter`
+   * is called first, and if either the `routeData`'s or element's `beforeEnter`
+   * returns `false`, the activation process will stop at the current and subsequent nodes. If
+   * `routeEnter` returns `false`, subsequent `routeEnter` calls down the tree
+   * are skipped. The `routingElement` is expected to implement `routeExit` and `routeEnter`.
    *
    *      _Root_
    *     /      \
@@ -237,13 +246,13 @@ class RouteTreeNode {
    * If the current route is "B" and the route for "E" is activated,
    * then the following callbacks should be invoked:
    *
-   *     B.exitCallback, A.exitCallback, Root.entryCallback,
-   *     D.entryCallback, E.entryCallback
+   *     B.routeExit, A.routeExit, Root.beforeEnter, Root.routeEnter,
+   *     D.beforeEnter, D.routeEnter, E.beforeEnter, E.routeEnter
    *
    * If the current route is "B" and the route for "C" is activated,
    * then the following callbacks should be invoked:
    *
-   *     B.exitCallback, Root.entryCallback, A.entryCallback, C.entryCallback
+   *     B.routeExit, Root.beforeEnter, Root.routeEnter, A.beforeEnter, A.routeEnter, C.beforeEnter, C.routeEnter
    *
    * @param {!string|undefined} previousRouteId
    * @param {!Context} context

--- a/lib/routing-interface.js
+++ b/lib/routing-interface.js
@@ -1,5 +1,5 @@
 import RouteTreeNode from './route-tree-node.js';
-import {Context} from './page.js';
+import { Context } from './page.js';
 
 /** @interface */
 class BasicRoutingInterface {
@@ -13,7 +13,7 @@ class BasicRoutingInterface {
    * @param {!Context} context
    * @return {!Promise<boolean|void>}
    */
-  async routeEnter(currentNode, nextNodeIfExists, routeId, context) { }
+  async routeEnter(currentNode, nextNodeIfExists, routeId, context) {}
 
   /**
    * Default implementation for the callback on exiting a route node.
@@ -25,7 +25,17 @@ class BasicRoutingInterface {
    * @param {!Context} context
    * @return {!Promise<void>}
    */
-  async routeExit(currentNode, nextNode, routeId, context) { }
-};
+  async routeExit(currentNode, nextNode, routeId, context) {}
 
-export {BasicRoutingInterface as default};
+  /**
+   * @param {!RouteTreeNode} currentNode
+   * @param {!RouteTreeNode|undefined} nextNodeIfExists
+   * @param {string} routeId
+   * @param {!Context} context
+   * @return {!Promise<boolean|void>}
+   * @optional
+   */
+  async beforeEnter(currentNode, nextNodeIfExists, routeId, context) {}
+}
+
+export { BasicRoutingInterface as default };

--- a/lib/routing-mixin.js
+++ b/lib/routing-mixin.js
@@ -1,6 +1,6 @@
 import RouteTreeNode from './route-tree-node.js';
 import RouteData from './route-data.js';
-import {Context} from './page.js';
+import { Context } from './page.js';
 import BasicRoutingInterface from './routing-interface.js';
 
 /**
@@ -31,7 +31,7 @@ function routingMixin(Superclass) {
       if (nextNodeIfExists) {
         const nextNode = /** @type {!RouteTreeNode} */ (nextNodeIfExists);
 
-        const nextNodeData = /** @type {!RouteData} */(nextNode.getValue());
+        const nextNodeData = /** @type {!RouteData} */ (nextNode.getValue());
 
         const thisElem = /** @type {!Element} */ (/** @type {?} */ (this));
         /** @type {Element} */
@@ -42,7 +42,6 @@ function routingMixin(Superclass) {
           if (nextNodeData.tagName.indexOf('-') > 0) {
             let Elem = customElements && customElements.get(nextNodeData.tagName.toLowerCase());
             if (!Elem) {
-              await nextNodeData.beforeEnter();
               // When code splitting, it's possible that the element created is not yet in the registry.
               // Wait until it is before creating it
               await customElements.whenDefined(nextNodeData.tagName.toLowerCase());
@@ -88,7 +87,21 @@ function routingMixin(Superclass) {
         await setElementAttributes(1, nextElement);
       }
     }
-
+    /*
+     * @param {!RouteTreeNode} currentNode
+     * @param {!RouteTreeNode|undefined} nextNode
+     * @param {string} routeId
+     * @param {!Context} context
+     * @return {!Promise<void>}
+     */
+    async beforeEnter(currentNode, nextNodeIfExists, routeId, context) {
+      if (nextNodeIfExists === undefined) {
+        return;
+      }
+      // await currentNode.getValue().beforeEnter(currentNode, nextNode, routeId, context);
+      const nextNodeData = /** @type {!RouteData} */ (nextNodeIfExists?.getValue());
+      await nextNodeData.beforeEnter(currentNode, nextNodeIfExists, routeId, context);
+    }
     /**
      * Default implementation for the callback on exiting a route node.
      * This will only be used if an element does not define it's own routeExit method.

--- a/lib/routing.mixin.ts
+++ b/lib/routing.mixin.ts
@@ -4,6 +4,7 @@ import type RouteTreeNode from './route-tree-node.js';
 import routingMixin from './routing-mixin.js';
 export type Constructor<T = {}> = new (...args: any[]) => T;
 export declare class RoutingMixinInterface {
+  beforeEnter(currentNode: RouteTreeNode, nextNodeIfExists: RouteTreeNode | undefined, routeId: string, context: Context): Promise<boolean | void>;
   routeEnter(currentNode: RouteTreeNode, nextNodeIfExists: RouteTreeNode | undefined, routeId: string, context: Context): Promise<boolean | void>;
   routeExit(currentNode: RouteTreeNode, nextNode: RouteTreeNode | undefined, routeId: string, context: Context): Promise<boolean | void>;
 }

--- a/router.js
+++ b/router.js
@@ -24,11 +24,13 @@
  *  authenticated: (boolean|undefined),
  *  subRoutes: (Array<RouteConfig>|undefined),
  *  beforeEnter: (function():Promise)
+ *  routeEnter: (function():Promise)
+ *  routeExit: (function():Promise)
  * }} RouteConfig
  */
 let RouteConfig;
 
-import {Context, Page} from './lib/page.js';
+import { Context, Page } from './lib/page.js';
 import RouteTreeNode from './lib/route-tree-node.js';
 import routingMixin from './lib/routing-mixin.js';
 import animatedRoutingMixin from './lib/animated-routing-mixin.js';
@@ -50,9 +52,13 @@ class Router {
     this.nextStateWasPopped = false;
 
     // Uses the capture phase so that this executes before the page.js handler
-    window.addEventListener('popstate', (evt) => {
-      this.nextStateWasPopped = true;
-    }, true);
+    window.addEventListener(
+      'popstate',
+      (evt) => {
+        this.nextStateWasPopped = true;
+      },
+      true,
+    );
 
     /** @type {!Set<!function():?>} */
     this.routeChangeStartCallbacks_ = new Set();
@@ -84,10 +90,21 @@ class Router {
 
   /** @param {!RouteConfig} routeConfig */
   buildRouteTree(routeConfig) {
-    const authenticated = [true, false].includes(routeConfig.authenticated) ?  routeConfig.authenticated : true;
-    const node = new RouteTreeNode(new RouteData(routeConfig.id, routeConfig.tagName, routeConfig.path, routeConfig.params || [], authenticated, routeConfig.beforeEnter));
+    const authenticated = [true, false].includes(routeConfig.authenticated) ? routeConfig.authenticated : true;
+    const node = new RouteTreeNode(
+      new RouteData(
+        routeConfig.id,
+        routeConfig.tagName,
+        routeConfig.path,
+        routeConfig.params || [],
+        authenticated,
+        routeConfig.beforeEnter,
+        routeConfig.routeEnter,
+        routeConfig.routeExit,
+      ),
+    );
     if (routeConfig.subRoutes) {
-      routeConfig.subRoutes.forEach(route => {
+      routeConfig.subRoutes.forEach((route) => {
         node.addChild(this.buildRouteTree(route));
       });
     }
@@ -110,7 +127,7 @@ class Router {
       hashbang: false,
       decodeURLComponents: true,
       window: undefined,
-      dispatch: undefined
+      dispatch: undefined,
     });
   }
 
@@ -302,4 +319,4 @@ class Router {
 }
 
 export default Router;
-export {animatedRoutingMixin, BasicRoutingInterface, Context, RouteData, RouteTreeNode, routingMixin};
+export { animatedRoutingMixin, BasicRoutingInterface, Context, RouteData, RouteTreeNode, routingMixin };

--- a/test/route-tree-node-spec.js
+++ b/test/route-tree-node-spec.js
@@ -70,7 +70,7 @@ describe('RouteTreeNode', () => {
 
     it('activating a route without a previous route id only invokes entry methods', async () => {
       await C.activate(undefined, new Context('/C'));
-      expect(routePath.join('_')).toBe('ROOT-enter_A-enter_C-enter');
+      expect(routePath.join('_')).toBe('ROOT-beforeEnter_ROOT-enter_A-beforeEnter_A-enter_C-beforeEnter_C-enter');
     });
 
     it('activating a route should call the correct methods', async () => {
@@ -80,7 +80,7 @@ describe('RouteTreeNode', () => {
 
     it('activating a route should call the correct methods 2', async () => {
       await C.activate(B.getKey(), new Context('/C'));
-      expect(routePath.join('_')).toBe('B-exit_ROOT-enter_A-enter_C-enter');
+      expect(routePath.join('_')).toBe('B-exit_ROOT-beforeEnter_ROOT-enter_A-beforeEnter_A-enter_C-beforeEnter_C-enter');
     });
 
     it('returning "false" from the routeEnter method should prevent future methods from being invoked', async () => {
@@ -89,7 +89,7 @@ describe('RouteTreeNode', () => {
         return Promise.resolve(false);
       });
       await C.activate(E.getKey(), new Context('/D/E'));
-      expect(routePath.join('_')).toBe('E-exit_D-exit_ROOT-enter_A-enter');
+      expect(routePath.join('_')).toBe('E-exit_D-exit_ROOT-beforeEnter_ROOT-enter_A-beforeEnter_A-enter');
     });
   });
 });

--- a/test/route-tree-node-spec.js
+++ b/test/route-tree-node-spec.js
@@ -33,6 +33,9 @@ describe('RouteTreeNode', () => {
       super();
       this.keyName = keyName;
     }
+    async beforeEnter(node, nextNode, routeId, context) {
+      routePath.push(`${this.keyName}-beforeEnter`);
+    }
     async routeEnter(node, nextNode, routeId, context) {
       routePath.push(`${this.keyName}-enter`);
     }
@@ -72,7 +75,7 @@ describe('RouteTreeNode', () => {
 
     it('activating a route should call the correct methods', async () => {
       await E.activate(B.getKey(), new Context('/D/E'));
-      expect(routePath.join('_')).toBe('B-exit_A-exit_ROOT-enter_D-enter_E-enter');
+      expect(routePath.join('_')).toBe('B-exit_A-exit_ROOT-beforeEnter_ROOT-enter_D-beforeEnter_D-enter_E-beforeEnter_E-enter');
     });
 
     it('activating a route should call the correct methods 2', async () => {


### PR DESCRIPTION
This adds the beforeEnter lifecycle method as a top level lifecycle method in the router like routeEnter and routeExit. It also provides optionality to setup beforeEnter, routeEnter, routeExit methods in the route config and/or the overriden methods like we have today. 

Testing:
1. Create a router config that has the standard lifecycle hooks routeEnter, routeExit, beforeEnter and ensure they get called in proper sequence. 
2. Ensure that you can define both route config lifecycle hooks, and lifecycle hooks in LitElement and they will be called in the correct order. Additionally ensure that the LitElement callbacks are called after the route config callbacks.
3. Ensure that the beforeEnter hooks now get called on root level nodes in addition to child nodes (previously restricted only to child nodes).

Example routing configuration with new lifecycle methods:
```js
const ROOT_PATH = 'example-app';

/** @enum {string} */
const ROUTE_PATHS = {
  app: ROOT_PATH,
  dashboard: '/',
};

/** @enum {string} tag name mapping */
const ROUTE_IDS = {
  app: 'example-app',
  dashboard: 'example-app-dashboard'
};

const ROUTE_CONFIG = {
  id: ROUTE_IDS.app,
  path: ROUTE_PATHS.app,
  tagName: ROUTE_IDS.app,
  beforeEnter: async (currentNode, nextNodeIfExists, routeId, context) => {
    console.log('root beforeEnter');
    //do something
  },
  routeEnter: async (currentNode, nextNodeIfExists, routeId, context) => {
    console.log('root routeEnter');
    //do something
  },
  routeExit: async (currentNode, nextNode, routeId, context) => {
    console.log('root routeExit');
    //do something
  },
  subRoutes: [
    {
      id: ROUTE_IDS.dashboard,
      path: ROUTE_PATHS.dashboard,
      tagName: ROUTE_IDS.dashboard,
      beforeEnter: async (currentNode, nextNodeIfExists, routeId, context) => {
        console.log('dashboard beforeEnter');
        import('../../components/example-app-dashboard.js');
      },
      routeEnter: async (currentNode, nextNodeIfExists, routeId, context) => {
        console.log('dashboard routeEnter');
        //do something
      },
      routeExit: async (currentNode, nextNode, routeId, context) => {
        console.log('dashboard routeExit');
        //do something
      },
    },
};
```
