### PR TITLE
feat: allow routeExit to cancel further routing, pushState

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ class MyElement extends routingMixin(HTMLElement) {
    * @param {!RouteTreeNode|undefined} nextNode - parent node
    * @param {string} routeId - unique name of the route
    * @param {!Context} context - page.js Context object
+   * @return {!Promise<boolean=>}
    */
   async routeExit(currentNode, nextNode, routeId, context) {
     const currentElement = currentNode.getValue().element;

--- a/README.md
+++ b/README.md
@@ -191,8 +191,10 @@ required.
 
 ## Creating Routing Enabled Components
 
-Components used with the router do not need to handle routeEnter and routeExit, but may take action at these lifecycle events by extending the routingMixin and overriding these methods.
-When using these methods, to continue routing you must use a super call to the base method (demonstrated below).
+Components used with the router do not need to handle `routeEnter()` and `routeExit()`, but may take action at these lifecycle events by extending the `routingMixin` and overriding these methods.
+When using these methods, to continue routing you must use a super call to the base method (demonstrated below). If a previous node's `routeExit()` or the new node's `routeEnter()` method returns `false`, the routing is halted and state is not pushed.
+
+_Note: In order to cancel routing on route entry, it must be canceled at the base route's `routeEnter()`; otherwise, state will already have been pushed and the element will already have been added to the DOM._
 
 ```js
 class MyElement extends routingMixin(HTMLElement) {
@@ -202,6 +204,7 @@ class MyElement extends routingMixin(HTMLElement) {
    * is shared between the old and new routes, the element
    * will be re-used but have attributes updated here.
    *
+   * @override
    * @param {!RouteTreeNode} currentNode
    * @param {!RouteTreeNode|undefined} nextNodeIfExists - the
    *     child node of this route.
@@ -223,6 +226,7 @@ class MyElement extends routingMixin(HTMLElement) {
    * This method is ONLY called if this element is not being
    * used by the next route destination.
    *
+   * @override
    * @param {!RouteTreeNode} currentNode
    * @param {!RouteTreeNode|undefined} nextNode - parent node
    * @param {string} routeId - unique name of the route
@@ -241,7 +245,7 @@ class MyElement extends routingMixin(HTMLElement) {
 ```
 
 Two mixins are provided to make this easy. When
-using the mixin, `routeEnter` and `routeExit` methods are only need defined
+using the mixin, `routeEnter()` and `routeExit()` methods only need to be defined
 when the default behavior needs modified. In most cases any overridden
 method should do minimal work and call `super.routeEnter` or `super.routeExit`.
 

--- a/demo/src/components/section-a1-route.js
+++ b/demo/src/components/section-a1-route.js
@@ -38,6 +38,14 @@ class SectionA1Route extends routingMixin(LitElement) {
     this.activeRouteId = routeId;
   }
 
+  async routeExit(currentNode, nextNode, routeId, context) {
+    // Demonstrate custom handling of route exit by asking the user to confirm leaving the route.
+    if (!confirm('Are you sure you want to leave this route?')) {
+      return false;
+    }
+    await super.routeExit(currentNode, nextNode, routeId, context);
+  }
+
   render() {
     return html`
       <h1>Section A1</h1>

--- a/lib/page.js
+++ b/lib/page.js
@@ -702,7 +702,8 @@ export class Context {
 
   /** @param {boolean} value */
   set handled(value) {
-    if (this.handled_ !== true && value === true && this.pushState_ !== false) {
+    if (this.handled_ !== true && value === true && this.shouldPushState !== false) {
+      // push state when changing from unhandled to handled
       this.pushState();
     }
     this.handled_ = value;
@@ -711,6 +712,22 @@ export class Context {
   /** @return {boolean} */
   get handled() {
     return this.handled_;
+  }
+
+  /**
+   * Set whether to push state when context is handled. (default: true)
+   * @param {boolean} value
+   */
+  set shouldPushState(value) {
+    this.pushState_ = value;
+  }
+
+  /**
+   * Returns whether state will be pushed when context is handled.
+   * @return {boolean}
+   */
+  get shouldPushState() {
+    return this.pushState_;
   }
 
   /** Push state. */

--- a/lib/route-tree-node.js
+++ b/lib/route-tree-node.js
@@ -283,6 +283,9 @@ class RouteTreeNode {
       }
     }
 
+    /** @type {boolean|void} */
+    let shouldContinue = true;
+
     // Exit nodes
     for (let exitIndex = 0; exitIndex < exitNodes.length; exitIndex++) {
       const currentExitNode = exitNodes[exitIndex];
@@ -293,12 +296,22 @@ class RouteTreeNode {
             /** @type {?} */ (currentExitNode.getValue().element)
         );
         if (routingElem.routeExit) {
-          await routingElem.routeExit(currentExitNode, nextExitNode, routeId, context);
+          shouldContinue = await routingElem.routeExit(currentExitNode, nextExitNode, routeId, context);
         } else {
           await removeRouteNode(currentExitNode);
         }
         value.element = undefined;
+        if (shouldContinue === false) {
+          break;
+        }
       }
+    }
+
+    if (shouldContinue === false) {
+      // routeExit handler canceled further routing; prevent pushState and mark as handled
+      context.shouldPushState = false;
+      context.handled = true;
+      return;
     }
 
     // entry nodes
@@ -310,8 +323,6 @@ class RouteTreeNode {
         const routingElem = /** @type {!BasicRoutingInterface} */ (
             /** @type {?} */ (currentEntryNode.getValue().element)
         );
-        /** @type {boolean|void} */
-        let shouldContinue = true;
         if(routingElem.routeEnter) {
           shouldContinue = await routingElem.routeEnter(currentEntryNode, nextEntryNode, routeId, context);
         } else {
@@ -321,6 +332,13 @@ class RouteTreeNode {
           break;
         }
       }
+    }
+
+    if (shouldContinue === false) {
+      // routeEnter handler canceled further routing; prevent pushState and mark as handled
+      context.shouldPushState = false;
+      context.handled = true;
+      return;
     }
   }
 }

--- a/lib/route-tree-node.js
+++ b/lib/route-tree-node.js
@@ -297,13 +297,13 @@ class RouteTreeNode {
         );
         if (routingElem.routeExit) {
           shouldContinue = await routingElem.routeExit(currentExitNode, nextExitNode, routeId, context);
+          if (shouldContinue === false) {
+            break;
+          }
         } else {
           await removeRouteNode(currentExitNode);
         }
         value.element = undefined;
-        if (shouldContinue === false) {
-          break;
-        }
       }
     }
 

--- a/lib/route-tree-node.js
+++ b/lib/route-tree-node.js
@@ -249,6 +249,7 @@ class RouteTreeNode {
    *
    * @param {!string|undefined} previousRouteId
    * @param {!Context} context
+   * @return {Promise<boolean>} Returns a promise that resolves to a boolean indicating whether the route activation should continue.
    */
   async activate(previousRouteId, context) {
     const routeId = this.getKey();
@@ -311,7 +312,7 @@ class RouteTreeNode {
       // routeExit handler canceled further routing; prevent pushState and mark as handled
       context.shouldPushState = false;
       context.handled = true;
-      return;
+      return false;
     }
 
     // entry nodes
@@ -338,8 +339,10 @@ class RouteTreeNode {
       // routeEnter handler canceled further routing; prevent pushState and mark as handled
       context.shouldPushState = false;
       context.handled = true;
-      return;
+      return false;
     }
+
+    return true;
   }
 }
 

--- a/lib/routing-interface.js
+++ b/lib/routing-interface.js
@@ -23,7 +23,7 @@ class BasicRoutingInterface {
    * @param {!RouteTreeNode|undefined} nextNode
    * @param {string} routeId
    * @param {!Context} context
-   * @return {!Promise<void>}
+   * @return {!Promise<boolean|void>}
    */
   async routeExit(currentNode, nextNode, routeId, context) { }
 };

--- a/lib/routing-mixin.js
+++ b/lib/routing-mixin.js
@@ -36,7 +36,7 @@ function routingMixin(Superclass) {
      * @param {!RouteTreeNode|undefined} nextNode
      * @param {string} routeId
      * @param {!Context} context
-     * @return {!Promise<void>}
+     * @return {!Promise<boolean|void>}
      */
     async routeExit(currentNode, nextNode, routeId, context) {
       return removeRouteNode(currentNode);

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "README.md"
   ],
   "scripts": {
-    "build": "tsc && yarn build:ts",
+    "build": "npm run clean && tsc && yarn build:ts",
     "build:ts": "tsc --project tsconfig.buildts.json",
     "clean": "rimraf ./lib/**/*.d.ts ./*.d.ts ./lib/*.mixin.js --glob",
     "prepublish": "yarn clean && yarn build",

--- a/router.js
+++ b/router.js
@@ -272,15 +272,17 @@ class Router {
     for (const cb of this.routeChangeStartCallbacks_) {
       cb();
     }
-    this.prevNodeId_ = this.currentNodeId_;
-    this.currentNodeId_ = routeTreeNode.getKey();
     /** @type {!Error|undefined} */
     let routeError;
     try {
-      await routeTreeNode.activate(this.prevNodeId, context);
+      if (!(await routeTreeNode.activate(this.currentNodeId_, context))) {
+        return;
+      }
     } catch (err) {
       routeError = err;
     }
+    this.prevNodeId_ = this.currentNodeId_;
+    this.currentNodeId_ = routeTreeNode.getKey();
     next();
     this.nextStateWasPopped = false;
     for (const cb of this.routeChangeCompleteCallbacks_) {

--- a/router.js
+++ b/router.js
@@ -276,6 +276,7 @@ class Router {
     let routeError;
     try {
       if (!(await routeTreeNode.activate(this.currentNodeId_, context))) {
+        next();
         return;
       }
     } catch (err) {

--- a/test/context-spec.js
+++ b/test/context-spec.js
@@ -1,0 +1,63 @@
+/**
+ * @fileoverview Tests for Context class
+ * @suppress {visibility} Tests are allowed to access private methods
+ */
+
+import { describe, it, expect } from 'vitest';
+import {Context} from '../lib/page.js';
+
+describe('Context', () => {
+  describe('set handled()', () => {
+    let context;
+    beforeEach(() => {
+      context = new Context('/test-path');
+      vi.spyOn(context, 'pushState').mockImplementation(() => {});
+    });
+    it('sets the handled flag to true', () => {
+      expect(context.handled).toBeFalsy();
+      context.handled = true;
+      expect(context.handled).toBe(true);
+    });
+
+    const PUSH_STATE_TEST = [{
+      initial: false,
+      newValue: true,
+      shouldPushStateValue: true,
+      shouldCallPushState: true, // this is the only case where pushState should be called
+    }, {
+      initial: true,
+      newValue: true,
+      shouldPushStateValue: false,
+      shouldCallPushState: false,
+    }, {
+      initial: false,
+      newValue: false,
+      shouldPushStateValue: false,
+      shouldCallPushState: false,
+    }, {
+      initial: true,
+      newValue: false,
+      shouldPushStateValue: false,
+      shouldCallPushState: false,
+    }];
+
+    PUSH_STATE_TEST.forEach((testCase) => {
+      describe(`when handled is ${testCase.initial}, new value is ${testCase.newValue}, and shouldPushState is ${testCase.shouldPushState}`, () => {
+        beforeEach(() => {
+          context.handled_ = testCase.initial;
+          context.pushState_ = testCase.shouldPushState;
+          expect(context.handled).toBe(testCase.initial);
+        });
+        it(`${testCase.shouldCallPushState ? '' : 'does not '}call pushState()`, () => {
+          context.handled = testCase.newValue;
+          expect(context.handled).toBe(testCase.newValue);
+          if (testCase.shouldCallPushState) {
+            expect(context.pushState).toHaveBeenCalled();
+          } else {
+            expect(context.pushState).not.toHaveBeenCalled();
+          }
+        });
+      });
+    });
+  });
+});

--- a/test/route-tree-node-spec.js
+++ b/test/route-tree-node-spec.js
@@ -16,6 +16,7 @@ import { describe, it, expect, vi } from 'vitest';
 import RouteTreeNode from '../lib/route-tree-node.js';
 import { loadRouteNode } from '../lib/route-change-handlers.js';
 import {Context} from '../router.js';
+import { exit } from 'node:process';
 
 describe('RouteTreeNode', () => {
   const ROOT = testRouteTree.tree.getNodeByKey(testRouteTree.Id.ROOT);
@@ -106,26 +107,38 @@ describe('RouteTreeNode', () => {
     });
 
     describe('when routeExit returns false', () => {
+      let pushStateSpy;
+      let context;
       beforeEach(() => {
         vi.spyOn(A.getValue().element, 'routeExit').mockImplementation(function() {
           routePath.push('A-exit');
           return Promise.resolve(false);
         });
+
+        context = new Context('/D/E');
+        pushStateSpy = vi.spyOn(context, 'pushState');
+        expect(context.handled).toBeFalsy(); // sanity check
+        context.shouldPushState = true; // should initially be true to test that it gets set to false
       });
-      it('prevents future methods from being invoked', async () => {
+      it('prevents future routes from being invoked', async () => {
         await E.activate(C.getKey(), new Context('/D/E'));
         expect(routePath.join('_')).toBe('C-exit_A-exit');
       });
-      it('sets context to handled and prevents pushState', async () => {
-        const context = new Context('/D/E');
-        expect(context.handled).toBeFalsy();
-        context.shouldPushState = true; // should initially be true to test that it gets set to false
-        const pushStateSpy = vi.spyOn(context, 'pushState');
+      it('sets context to handled', async () => {
         await E.activate(C.getKey(), context);
-        expect(routePath.join('_')).toBe('C-exit_A-exit');
         expect(context.handled).toBe(true);
+      });
+      it('prevents pushState', async () => {
+        await E.activate(C.getKey(), context);
         expect(context.shouldPushState).toBe(false);
         expect(pushStateSpy).not.toHaveBeenCalled();
+      });
+      it('does not clear exit node element', async () => {
+        const exitNode = A.getValue();
+        expect(exitNode.element).toBeInstanceOf(RoutedElement);
+
+        await E.activate(C.getKey(), context);
+        expect(A.getValue().element).toBeDefined();
       });
     });
 

--- a/test/router-spec.js
+++ b/test/router-spec.js
@@ -14,74 +14,71 @@ import testRouteTree from './utils/testing-route-setup.js';
 import testRouteConfig from './utils/test-route-config.js';
 import Router, {Context, RouteTreeNode} from '../router.js';
 import RoutedElement from './fixtures/custom-fixture.js';
-import {expect, vi} from 'vitest';
+import {afterEach, beforeEach, describe, expect, vi} from 'vitest';
+import { ROOT, A, B, C, D, E } from './utils/testing-route-setup.js';
 
 function JSCompiler_renameProperty(propName, instance) {
   return propName;
 }
 
 describe('Router', () => {
-  beforeEach(() => {
-    Router.instance_ = null;
-  });
+  let router;
 
-  afterAll(() => {
-    Router.instance_ = null;
-  });
-  let router = new Router();
-
-  const A = testRouteTree.tree.getNodeByKey(testRouteTree.Id.A);
-  const B = testRouteTree.tree.getNodeByKey(testRouteTree.Id.B);
-
-  const originalRouteChangeCallback = router.routeChangeCallback_;
   /** @type {!Function} */
   let newRouteChangeCallback;
 
-  const startPropertyName = JSCompiler_renameProperty('start', router.page);
+  const startPropertyName = JSCompiler_renameProperty('start', Router.prototype.page);
 
-  beforeAll(() => {
-    // reset router
+  const initRouter = async () => {
+    history.pushState({}, '', '/'); // reset URL to prevent page.js from invoking route callbacks on page load
+    Router.instance_ = null; // reset singleton instance to force creating new instance
+    newRouteChangeCallback = undefined; // reset newRouteChangeCallback to prevent tests from affecting each other
+    router = new Router();
     router.routeTree = testRouteTree.tree;
-
     router.routeChangeCallback_ = (function(...args) {
-      originalRouteChangeCallback.apply(this, args);
+      Router.prototype.routeChangeCallback_.apply(this, args);
       if (newRouteChangeCallback) {
         newRouteChangeCallback.apply(this, args);
       }
     }).bind(router);
 
+    // should start with no current or previous route
+    expect(router.prevNodeId_).toBe(undefined); // sanity check
+    expect(router.currentNodeId_).toBe(undefined); // sanity check
+
+    await router.start();
     router.page.register('*', (context, next) => {
       context.handled = true; // prevents actually leaving the page
       next();
     });
+
+    expect(router.prevNodeId_).toBe(undefined); // sanity check
+    expect(router.currentNodeId_).toBe(testRouteTree.Id.ROOT); // sanity check
+  };
+
+  beforeEach(async () => {
+    await initRouter();
   });
 
-  afterAll(() => {
-    // reset router
-    router.currentNodeId_ = undefined;
-  });
+  describe('start()', () => {
+    beforeEach(() => {
+      // re-initialize without registering route callbacks
+      Router.instance_ = null; // reset singleton instance to force creating new instance
+      router = new Router();
+      router.routeTree = testRouteTree.tree;
+    });
 
-  beforeEach(() => {
-    vi.spyOn(router.page, startPropertyName);
-  });
+    it('registers routes and start routing', () => {
+      const initialCallbackLength = router.page.callbacks.length;
+      const builtinCallbackLength = 0;
 
-  it('.start should register routes and start routing', () => {
-    const initialCallbackLength = router.page.callbacks.length;
-    const builtinCallbackLength = 0;
-
-    router.start();
-    // router.page should be called to register routes ROOT, B, C, D, E.
-    // A should NOT be registered as it is abstract (has a zero length path).
-    expect(router.page.callbacks.length).toBe(5 + initialCallbackLength + builtinCallbackLength);
-    expect(router.page.start).toHaveBeenCalled();
-  });
-
-  it('should not have a current route id initially', () => {
-    expect(router.currentNodeId_).toBe(undefined);
-  });
-
-  it('should not have a previous route id initially', () => {
-    expect(router.prevNodeId_).toBe(undefined);
+      vi.spyOn(router.page, startPropertyName);
+      router.start();
+      // router.page should be called to register routes ROOT, B, C, D, E.
+      // A should NOT be registered as it is abstract (has a zero length path).
+      expect(router.page.callbacks.length).toBe(5 + initialCallbackLength + builtinCallbackLength);
+      expect(router.page.start).toHaveBeenCalled();
+    });
   });
 
   it('callbacks should call router.routeChangeCallback_ with the correct this binding and arguments', async () => {
@@ -265,8 +262,6 @@ describe('Router', () => {
       expect(rp instanceof Context);
     });
   });
-
-
 
   describe('query context', () => {
     afterEach(() => {

--- a/test/router-spec.js
+++ b/test/router-spec.js
@@ -254,22 +254,16 @@ describe('Router', () => {
       router.page.callbacks.pop();
     });
 
-    it('should be an empty object if there are no query parameters', (done) => {
-      router.page.register('/test', (context, next) => {
-        expect(context.query).toBeInstanceOf(URLSearchParams);
-        expect(Array.from(context.query.keys())).toEqual([]);
-        done();
-      });
-      router.go('/test');
+    it('should be an empty object if there are no query parameters', async () => {
+      const context = await router.go('/test');
+      expect(context.query).toBeInstanceOf(URLSearchParams);
+      expect(Array.from(context.query.keys())).toEqual([]);
     });
 
-    it('should have properties that match the query parameters', (done) => {
-      router.page.register('/test', (context, next) => {
-        expect(context.query.get('foo')).toBe('bar');
-        expect(context.query.get('noValue')).toBe('');
-        done();
-      });
-      router.go('/test?foo=bar&noValue');
+    it('should have properties that match the query parameters', async () => {
+      const context = await router.go('/test?foo=bar&noValue');
+      expect(context.query.get('foo')).toBe('bar');
+      expect(context.query.get('noValue')).toBe('');
     });
   });
 

--- a/test/router-spec.js
+++ b/test/router-spec.js
@@ -14,7 +14,7 @@ import testRouteTree from './utils/testing-route-setup.js';
 import testRouteConfig from './utils/test-route-config.js';
 import Router, {Context, RouteTreeNode} from '../router.js';
 import RoutedElement from './fixtures/custom-fixture.js';
-import {vi} from 'vitest';
+import {expect, vi} from 'vitest';
 
 function JSCompiler_renameProperty(propName, instance) {
   return propName;
@@ -76,29 +76,38 @@ describe('Router', () => {
     expect(router.page.start).toHaveBeenCalled();
   });
 
-  it('should not have a previous route id initially', () => {
+  it('should not have a current route id initially', () => {
     expect(router.currentNodeId_).toBe(undefined);
   });
 
+  it('should not have a previous route id initially', () => {
+    expect(router.prevNodeId_).toBe(undefined);
+  });
+
   it('callbacks should call router.routeChangeCallback_ with the correct this binding and arguments', async () => {
+    let routeChangeCallbackCalled = false;
     newRouteChangeCallback = (function(node, ...args) {
       expect(args.length).toBe(2);
       expect(this instanceof router.constructor).toBe(true);
       expect(node instanceof RouteTreeNode).toBe(true);
-
+      routeChangeCallbackCalled = true;
     }).bind(router);
 
-    router.go('/B/somedata');
+    await router.go('/B/somedata');
+    expect(routeChangeCallbackCalled).toBe(true);
   });
 
-  it('should store the previous route id', () => {
-    expect(router.currentNodeId_).toBe(testRouteTree.Id.B);
+  it('should store the previous route id', async () => {
+    await router.go('/B/somedata');
+    await router.go('/C');
+    expect(router.currentNodeId_).toBe(testRouteTree.Id.C);
+    expect(router.prevNodeId_).toBe(testRouteTree.Id.B);
   });
 
   describe('Router constructor', () => {
-    afterAll(() => {
-      // reset routeTree
-      router = new Router();
+    beforeEach(() => {
+      // reset singleton instance before each test to prevent tests from affecting each other
+      Router.instance_ = null;
     });
 
     it('should leave the routeTree undefined if instantiated without a route configuration', () => {
@@ -109,6 +118,17 @@ describe('Router', () => {
     it('should create the routeTree when instantiated with the route configuration', () => {
       router = new Router(testRouteConfig);
       expect(router.routeTree).not.toBe(undefined);
+    });
+
+    it('sets singleton instance', () => {
+      router = new Router();
+      expect(Router.instance_).toBe(router);
+    });
+
+    it('returns the singleton instance if the constructor is called multiple times', () => {
+      const router1 = new Router();
+      const router2 = new Router();
+      expect(router1).toBe(router2);
     });
   });
 

--- a/test/router-spec.js
+++ b/test/router-spec.js
@@ -94,13 +94,6 @@ describe('Router', () => {
     expect(routeChangeCallbackCalled).toBe(true);
   });
 
-  it('should store the previous route id', async () => {
-    await router.go('/B/somedata');
-    await router.go('/C');
-    expect(router.currentNodeId_).toBe(testRouteTree.Id.C);
-    expect(router.prevNodeId_).toBe(testRouteTree.Id.B);
-  });
-
   describe('Router constructor', () => {
     beforeEach(() => {
       // reset singleton instance before each test to prevent tests from affecting each other
@@ -353,6 +346,61 @@ describe('Router', () => {
       A.getValue().element.appendChild(bElement);
       await A.getValue().element.routeExit(B, A, testRouteTree.Id.E, context);
       expect(A.getValue().element.getElementsByTagName(testRouteTree.Id.B).length).toBe(0);
+    });
+  });
+
+  describe('routeChangeCallback_(routeTreeNode, context, next)', () => {
+    beforeEach(async () => {
+      expect(router.currentNodeId_).toBe(testRouteTree.Id.ROOT); // sanity check —- should start at ROOT
+      expect(router.prevNodeId_).toBe(undefined); // sanity check
+    });
+
+    describe('when routeTreeNode.activate() resolves to true', () => {
+      beforeEach(() => {
+        vi.spyOn(B, JSCompiler_renameProperty('activate', RouteTreeNode.prototype)).mockImplementation(async () => true);
+      });
+
+      it('stores the previous route id and updates the current route id', async () => {
+        await router.go('/B/somedata');
+        expect(router.prevNodeId_).toBe(testRouteTree.Id.ROOT);
+        expect(router.currentNodeId_).toBe(testRouteTree.Id.B);
+      });
+    });
+
+    describe('when routeTreeNode.activate() resolves to false (routing stopped)', () => {
+      beforeEach(() => {
+        vi.spyOn(B, JSCompiler_renameProperty('activate', RouteTreeNode.prototype)).mockImplementation(async () => false);
+      });
+
+      it('prevents prevNodeId_ and currentNodeId_ from being updated', async () => {
+        await router.go('/B/somedata');
+        expect(router.prevNodeId_).toBe(undefined); // prevNodeId_ should not update because routing was stopped
+        expect(router.currentNodeId_).toBe(testRouteTree.Id.ROOT); // currentNodeId_ should not update because routing was stopped
+      });
+    });
+
+    describe('when routeTreeNode.activate() throws an error', () => {
+      const error = new Error('test error');
+      beforeEach(() => {
+        vi.spyOn(B, JSCompiler_renameProperty('activate', RouteTreeNode.prototype)).mockImplementation(async () => { throw error });
+      });
+
+      it('updates previous route id and current route id', async () => {
+        await router.go('/B/somedata');
+        expect(router.prevNodeId_).toBe(testRouteTree.Id.ROOT);
+        expect(router.currentNodeId_).toBe(testRouteTree.Id.B);
+      });
+
+      it('should pass the error to route change complete callbacks', async () => {
+        let routeChangeCompleteCallbackCalled = false;
+        const routeChangeCompleteCallback = (err) => {
+          expect(err).toBe(error);
+          routeChangeCompleteCallbackCalled = true;
+        };
+        router.addRouteChangeCompleteCallback(routeChangeCompleteCallback);
+        await router.go('/B/somedata');
+        expect(routeChangeCompleteCallbackCalled).toBe(true);
+      });
     });
   });
 });

--- a/test/utils/testing-route-setup.js
+++ b/test/utils/testing-route-setup.js
@@ -43,15 +43,15 @@ for (const routeId in RouteId) {
   }
 }
 
-const E = new RouteTreeNode(new RouteData(RouteId.E, RouteId.E, '/D/E'));
-const D = new RouteTreeNode(new RouteData(RouteId.D, RouteId.D, '/D'));
+export const E = new RouteTreeNode(new RouteData(RouteId.E, RouteId.E, '/D/E'));
+export const D = new RouteTreeNode(new RouteData(RouteId.D, RouteId.D, '/D'));
 D.addChild(E);
-const C = new RouteTreeNode(new RouteData(RouteId.C, RouteId.C, '/C'));
-const B = new RouteTreeNode(new RouteData(RouteId.B, RouteId.B, '/B/:bData', ['bData'], false));
-const A = new RouteTreeNode(new RouteData(RouteId.A, RouteId.A, ''));
+export const C = new RouteTreeNode(new RouteData(RouteId.C, RouteId.C, '/C'));
+export const B = new RouteTreeNode(new RouteData(RouteId.B, RouteId.B, '/B/:bData', ['bData'], false));
+export const A = new RouteTreeNode(new RouteData(RouteId.A, RouteId.A, ''));
 A.addChild(B);
 A.addChild(C);
-const ROOT = new RouteTreeNode(new RouteData(RouteId.ROOT, RouteId.ROOT, '/', [], false));
+export const ROOT = new RouteTreeNode(new RouteData(RouteId.ROOT, RouteId.ROOT, '/', [], false));
 ROOT.addChild(A);
 ROOT.addChild(D);
 


### PR DESCRIPTION
## Summary
This adds the ability to return `false` in a `routeExit()` function to stop further routing. A common example of a use case for this feature is to enable checking for unsaved changes and showing a confirmation dialog before exiting the route to allow the user to confirm whether they want to discard their changes or not.

* Adds new `shouldPushState` accessors to `Context` to allow control of whether `pushState()` should be called when setting `handled` from `false` to `true`
* Updates `RouteTreeNode.prototype.activate()` so returning `false` in a `routeEnter()` always prevents any further routing, including any further `routeExit` or `routeEnter()` functions and 
   - The current behavior stops further `routeEnter` handlers from being called, but does not necessarily stop the unhandled route handler from firing. Generally, the top-level `routeEnter()` sets `context.handled = true`, but that may not always be the case. Setting both of these context properties fixes that. 
* Adds logic for `routeExit()` handlers to prevent further routing by returning `false` like `routeEnter` handlers. By setting the `context.shouldPushState` to `false`, `context.handled` to `true`, and returning, any further `routeExit` or `routeEnter` functions are prevented.
