### PR TITLE
chore(actions): upgrade actions and add labels on test workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,7 +1,7 @@
 # This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
-name: Tests
+name: Build and Test
 
 on:
   push:
@@ -11,17 +11,22 @@ on:
     types: [opened, synchronize, ready_for_review]
     paths-ignore:
       - '**/*.md'
+
 jobs:
-  test:
+  build-and-test:
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
-    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # 5.0.0
-    - name: run tests
-      uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # 5.0.0
+    - name: Checkout
+      uses: actions/checkout@v6
+    - name: Setup Node.js
+      uses: actions/setup-node@v6
       with:
-        node-version: '20.x'
-    - run: yarn install
-    - run: npx playwright install --with-deps chromium
-    - run: CI=1 yarn test
+        node-version: 24
+    - name: Install dependencies and build
+      run: yarn install
+    - name: Install Playwright dependencies
+      run: npx playwright install --with-deps chromium
+    - name: Run tests
+      run: CI=1 yarn test

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,9 +19,9 @@ jobs:
       contents: read
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
     - name: Setup Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # 6.4.0
       with:
         node-version: 24
     - name: Install dependencies and build

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,7 +13,7 @@ on:
       - '**/*.md'
 
 jobs:
-  build-and-test:
+  test:
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,9 +15,9 @@ jobs:
       FORCE_COLOR: '1'
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
       - name: Use Node.js 24
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # 6.4.0
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,9 +15,9 @@ jobs:
       FORCE_COLOR: '1'
     steps:
       - name: Checkout repo
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # 5.0.0
+        uses: actions/checkout@v6
       - name: Use Node.js 24
-        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # 5.0.0
+        uses: actions/setup-node@v6
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org/


### PR DESCRIPTION
## Summary

* Upgrades `actions/checkout` and `actions/setup-node` for both the build/test and publish workflows from version 5.0.0 to the latest v6
   - This 
* Adds some labels and renames the `test` workflow to `Build and test`