### PR TITLE
chore(actions): let the publish job write, so semantic-release can tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,8 +10,9 @@ jobs:
     if: github.ref_name == github.event.repository.default_branch
     permissions:
       id-token: write  # Required for OIDC
-      contents: read
+      contents: write
       issues: write
+      pull-requests: write
     runs-on: ubuntu-latest
     env:
       FORCE_COLOR: '1'


### PR DESCRIPTION
This grants `contents: write` for the version tag and the GitHub release, and `pull-requests: write` for the success step, which labels the released PRs and fails the job if it can't.
